### PR TITLE
Update BioBERT NER scripts for TensorFlow 2 compatibility

### DIFF
--- a/biobert_ner/fast_predict2.py
+++ b/biobert_ner/fast_predict2.py
@@ -13,6 +13,7 @@
     Author: Marc Stogaitis
  """
 import tensorflow as tf
+tf.compat.v1.disable_v2_behavior()
 import threading
 from biobert_ner.utils import Profile
 
@@ -78,9 +79,9 @@ def example_input_fn(generator):
     It must take a generator as input """
 
     def _inner_input_fn():
-        dataset = tf.data.Dataset().from_generator(
+        dataset = tf.data.Dataset.from_generator(
             generator, output_types=tf.float32).batch(1)
-        iterator = dataset.make_one_shot_iterator()
+        iterator = tf.compat.v1.data.make_one_shot_iterator(dataset)
         features = iterator.get_next()
         return {'x': features}
 

--- a/biobert_ner/modeling.py
+++ b/biobert_ner/modeling.py
@@ -25,6 +25,7 @@ import math
 import re
 import six
 import tensorflow as tf
+tf.compat.v1.disable_v2_behavior()
 
 
 class BertConfig(object):
@@ -89,7 +90,7 @@ class BertConfig(object):
     @classmethod
     def from_json_file(cls, json_file):
         """Constructs a `BertConfig` from a json file of parameters."""
-        with tf.gfile.GFile(json_file, "r") as reader:
+        with tf.io.gfile.GFile(json_file, "r") as reader:
             text = reader.read()
         return cls.from_dict(json.loads(text))
 
@@ -170,8 +171,8 @@ class BertModel(object):
             token_type_ids = tf.zeros(shape=[batch_size, seq_length],
                                       dtype=tf.int32)
 
-        with tf.variable_scope(scope, default_name="bert"):
-            with tf.variable_scope("embeddings"):
+        with tf.compat.v1.variable_scope(scope, default_name="bert"):
+            with tf.compat.v1.variable_scope("embeddings"):
                 # Perform embedding lookup on the word ids.
                 (
                 self.embedding_output, self.embedding_table) = embedding_lookup(
@@ -196,7 +197,7 @@ class BertModel(object):
                     max_position_embeddings=config.max_position_embeddings,
                     dropout_prob=config.hidden_dropout_prob)
 
-            with tf.variable_scope("encoder"):
+            with tf.compat.v1.variable_scope("encoder"):
                 # This converts a 2D mask of shape [batch_size, seq_length] to a 3D
                 # mask of shape [batch_size, seq_length, seq_length] which is used
                 # for the attention scores.
@@ -224,12 +225,12 @@ class BertModel(object):
             # [batch_size, hidden_size]. This is necessary for segment-level
             # (or segment-pair-level) classification tasks where we need a fixed
             # dimensional representation of the segment.
-            with tf.variable_scope("pooler"):
+            with tf.compat.v1.variable_scope("pooler"):
                 # We "pool" the model by simply taking the hidden state corresponding
                 # to the first token. We assume that this has been pre-trained
                 first_token_tensor = tf.squeeze(self.sequence_output[:, 0:1, :],
                                                 axis=1)
-                self.pooled_output = tf.layers.dense(
+                self.pooled_output = tf.compat.v1.layers.dense(
                     first_token_tensor,
                     config.hidden_size,
                     activation=tf.tanh,
@@ -359,16 +360,13 @@ def dropout(input_tensor, dropout_prob):
     """
     if dropout_prob is None or dropout_prob == 0.0:
         return input_tensor
-
-    output = tf.nn.dropout(input_tensor, 1.0 - dropout_prob)
+    output = tf.nn.dropout(input_tensor, rate=dropout_prob)
     return output
 
 
 def layer_norm(input_tensor, name=None):
     """Run layer normalization on the last dimension of the tensor."""
-    return tf.contrib.layers.layer_norm(
-        inputs=input_tensor, begin_norm_axis=-1, begin_params_axis=-1,
-        scope=name)
+    return tf.keras.layers.LayerNormalization(axis=-1, name=name)(input_tensor)
 
 
 def layer_norm_and_dropout(input_tensor, dropout_prob, name=None):
@@ -380,7 +378,7 @@ def layer_norm_and_dropout(input_tensor, dropout_prob, name=None):
 
 def create_initializer(initializer_range=0.02):
     """Creates a `truncated_normal_initializer` with the given range."""
-    return tf.truncated_normal_initializer(stddev=initializer_range)
+    return tf.compat.v1.truncated_normal_initializer(stddev=initializer_range)
 
 
 def embedding_lookup(input_ids,
@@ -413,7 +411,7 @@ def embedding_lookup(input_ids,
     if input_ids.shape.ndims == 2:
         input_ids = tf.expand_dims(input_ids, axis=[-1])
 
-    embedding_table = tf.get_variable(
+    embedding_table = tf.compat.v1.get_variable(
         name=word_embedding_name,
         shape=[vocab_size, embedding_size],
         initializer=create_initializer(initializer_range))
@@ -480,7 +478,7 @@ def embedding_postprocessor(input_tensor,
         if token_type_ids is None:
             raise ValueError("`token_type_ids` must be specified if"
                              "`use_token_type` is True.")
-        token_type_table = tf.get_variable(
+        token_type_table = tf.compat.v1.get_variable(
             name=token_type_embedding_name,
             shape=[token_type_vocab_size, width],
             initializer=create_initializer(initializer_range))
@@ -495,9 +493,9 @@ def embedding_postprocessor(input_tensor,
         output += token_type_embeddings
 
     if use_position_embeddings:
-        assert_op = tf.assert_less_equal(seq_length, max_position_embeddings)
+        assert_op = tf.debugging.assert_less_equal(seq_length, max_position_embeddings)
         with tf.control_dependencies([assert_op]):
-            full_position_embeddings = tf.get_variable(
+            full_position_embeddings = tf.compat.v1.get_variable(
                 name=position_embedding_name,
                 shape=[max_position_embeddings, width],
                 initializer=create_initializer(initializer_range))
@@ -672,7 +670,7 @@ def attention_layer(from_tensor,
     to_tensor_2d = reshape_to_matrix(to_tensor)
 
     # `query_layer` = [B*F, N*H]
-    query_layer = tf.layers.dense(
+    query_layer = tf.compat.v1.layers.dense(
         from_tensor_2d,
         num_attention_heads * size_per_head,
         activation=query_act,
@@ -680,7 +678,7 @@ def attention_layer(from_tensor,
         kernel_initializer=create_initializer(initializer_range))
 
     # `key_layer` = [B*T, N*H]
-    key_layer = tf.layers.dense(
+    key_layer = tf.compat.v1.layers.dense(
         to_tensor_2d,
         num_attention_heads * size_per_head,
         activation=key_act,
@@ -688,7 +686,7 @@ def attention_layer(from_tensor,
         kernel_initializer=create_initializer(initializer_range))
 
     # `value_layer` = [B*T, N*H]
-    value_layer = tf.layers.dense(
+    value_layer = tf.compat.v1.layers.dense(
         to_tensor_2d,
         num_attention_heads * size_per_head,
         activation=value_act,
@@ -834,12 +832,12 @@ def transformer_model(input_tensor,
 
     all_layer_outputs = []
     for layer_idx in range(num_hidden_layers):
-        with tf.variable_scope("layer_%d" % layer_idx):
+        with tf.compat.v1.variable_scope("layer_%d" % layer_idx):
             layer_input = prev_output
 
-            with tf.variable_scope("attention"):
+            with tf.compat.v1.variable_scope("attention"):
                 attention_heads = []
-                with tf.variable_scope("self"):
+                with tf.compat.v1.variable_scope("self"):
                     attention_head = attention_layer(
                         from_tensor=layer_input,
                         to_tensor=layer_input,
@@ -864,8 +862,8 @@ def transformer_model(input_tensor,
 
                 # Run a linear projection of `hidden_size` then add a residual
                 # with `layer_input`.
-                with tf.variable_scope("output"):
-                    attention_output = tf.layers.dense(
+                with tf.compat.v1.variable_scope("output"):
+                    attention_output = tf.compat.v1.layers.dense(
                         attention_output,
                         hidden_size,
                         kernel_initializer=create_initializer(
@@ -876,16 +874,16 @@ def transformer_model(input_tensor,
                         attention_output + layer_input)
 
             # The activation is only applied to the "intermediate" hidden layer.
-            with tf.variable_scope("intermediate"):
-                intermediate_output = tf.layers.dense(
+            with tf.compat.v1.variable_scope("intermediate"):
+                intermediate_output = tf.compat.v1.layers.dense(
                     attention_output,
                     intermediate_size,
                     activation=intermediate_act_fn,
                     kernel_initializer=create_initializer(initializer_range))
 
             # Down-project back to `hidden_size` then add the residual.
-            with tf.variable_scope("output"):
-                layer_output = tf.layers.dense(
+            with tf.compat.v1.variable_scope("output"):
+                layer_output = tf.compat.v1.layers.dense(
                     intermediate_output,
                     hidden_size,
                     kernel_initializer=create_initializer(initializer_range))
@@ -992,7 +990,7 @@ def assert_rank(tensor, expected_rank, name=None):
 
     actual_rank = tensor.shape.ndims
     if actual_rank not in expected_rank_dict:
-        scope_name = tf.get_variable_scope().name
+        scope_name = tf.compat.v1.get_variable_scope().name
         raise ValueError(
             "For the tensor `%s` in scope `%s`, the actual rank "
             "`%d` (shape = %s) is not equal to the expected rank `%s`" %

--- a/biobert_ner/run_ner.py
+++ b/biobert_ner/run_ner.py
@@ -12,6 +12,9 @@ from __future__ import print_function
 import os
 import threading
 import time
+import tensorflow as tf
+
+tf.compat.v1.disable_v2_behavior()
 
 from biobert_ner.modeling import *
 from biobert_ner.tokenization import *
@@ -21,7 +24,7 @@ from biobert_ner.fast_predict2 import FastPredict
 from convert import preprocess
 
 
-flags = tf.flags
+flags = tf.compat.v1.flags
 
 flags.DEFINE_string(
     "task_name", "NER", "The name of the task to train."
@@ -237,16 +240,16 @@ class NerProcessor(DataProcessor):
 
 def file_based_input_fn_builder(input_file, seq_length, drop_remainder):
     name_to_features = {
-        "input_ids": tf.FixedLenFeature([seq_length], tf.int64),
-        "input_mask": tf.FixedLenFeature([seq_length], tf.int64),
-        "segment_ids": tf.FixedLenFeature([seq_length], tf.int64),
-        "label_ids": tf.FixedLenFeature([seq_length], tf.int64),
+        "input_ids": tf.io.FixedLenFeature([seq_length], tf.int64),
+        "input_mask": tf.io.FixedLenFeature([seq_length], tf.int64),
+        "segment_ids": tf.io.FixedLenFeature([seq_length], tf.int64),
+        "label_ids": tf.io.FixedLenFeature([seq_length], tf.int64),
         # "label_ids":tf.VarLenFeature(tf.int64),
         # "label_mask": tf.FixedLenFeature([seq_length], tf.int64),
     }
 
     def _decode_record(record, name_to_features):
-        example = tf.parse_single_example(record, name_to_features)
+        example = tf.io.parse_single_example(record, name_to_features)
         for name in list(example.keys()):
             t = example[name]
             if t.dtype == tf.int64:
@@ -282,18 +285,18 @@ def create_model(bert_config, is_training, input_ids, input_mask,
 
     output_layer = model.get_sequence_output()
 
-    hidden_size = output_layer.shape[-1].value
+    hidden_size = int(output_layer.shape[-1])
 
-    output_weight = tf.get_variable(
+    output_weight = tf.compat.v1.get_variable(
         "output_weights", [num_labels, hidden_size],
-        initializer=tf.truncated_normal_initializer(stddev=0.02)
+        initializer=tf.compat.v1.truncated_normal_initializer(stddev=0.02)
     )
-    output_bias = tf.get_variable(
+    output_bias = tf.compat.v1.get_variable(
         "output_bias", [num_labels], initializer=tf.zeros_initializer()
     )
-    with tf.variable_scope("loss"):
+    with tf.compat.v1.variable_scope("loss"):
         if is_training:
-            output_layer = tf.nn.dropout(output_layer, keep_prob=0.9)
+            output_layer = tf.nn.dropout(output_layer, rate=0.1)
         output_layer = tf.reshape(output_layer, [-1, hidden_size])
         logits = tf.matmul(output_layer, output_weight, transpose_b=True)
         logits = tf.nn.bias_add(logits, output_bias)
@@ -327,20 +330,20 @@ def model_fn_builder(bert_config, num_labels, init_checkpoint, learning_rate,
             create_model(bert_config, is_training, input_ids, input_mask,
                          segment_ids, label_ids, num_labels,
                          use_one_hot_embeddings)
-        tvars = tf.trainable_variables()
+        tvars = tf.compat.v1.trainable_variables()
         scaffold_fn = None
         if init_checkpoint:
             (assignment_map, initialized_variable_names) = \
                 get_assignment_map_from_checkpoint(tvars, init_checkpoint)
             if use_tpu:
                 def tpu_scaffold():
-                    tf.train.init_from_checkpoint(init_checkpoint,
-                                                  assignment_map)
-                    return tf.train.Scaffold()
+                    tf.compat.v1.train.init_from_checkpoint(init_checkpoint,
+                                                            assignment_map)
+                    return tf.compat.v1.train.Scaffold()
 
                 scaffold_fn = tpu_scaffold
             else:
-                tf.train.init_from_checkpoint(init_checkpoint, assignment_map)
+                tf.compat.v1.train.init_from_checkpoint(init_checkpoint, assignment_map)
 
         for var in tvars:
             init_string = ""
@@ -349,7 +352,7 @@ def model_fn_builder(bert_config, num_labels, init_checkpoint, learning_rate,
 
         assert mode == tf.estimator.ModeKeys.PREDICT
 
-        output_spec = tf.contrib.tpu.TPUEstimatorSpec(
+        output_spec = tf.compat.v1.estimator.tpu.TPUEstimatorSpec(
             mode=mode,
             predictions={"prediction": predicts, "log_probs": log_probs},
             scaffold_fn=scaffold_fn
@@ -366,7 +369,7 @@ class BioBERT:
 
         os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
 
-        tf.logging.set_verbosity(tf.logging.INFO)
+        tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.INFO)
 
         bert_config = BertConfig.from_json_file(FLAGS.bert_config_file)
 
@@ -390,12 +393,12 @@ class BioBERT:
         tpu_cluster_resolver = None
         if FLAGS.use_tpu and FLAGS.tpu_name:
             tpu_cluster_resolver = \
-                tf.contrib.cluster_resolver.TPUClusterResolver(
+                tf.distribute.cluster_resolver.TPUClusterResolver(
                     FLAGS.tpu_name, zone=FLAGS.tpu_zone,
                     project=FLAGS.gcp_project)
 
-        is_per_host = tf.contrib.tpu.InputPipelineConfig.PER_HOST_V2
-        session_config = tf.ConfigProto()
+        is_per_host = tf.compat.v1.estimator.tpu.InputPipelineConfig.PER_HOST_V2
+        session_config = tf.compat.v1.ConfigProto()
         session_config.gpu_options.allow_growth = True
 
         self.estimator_dict = dict()
@@ -404,13 +407,13 @@ class BioBERT:
             num_train_steps = None
             num_warmup_steps = None
 
-            run_config = tf.contrib.tpu.RunConfig(
+            run_config = tf.compat.v1.estimator.tpu.RunConfig(
                 cluster=tpu_cluster_resolver,
                 master=FLAGS.master,
                 model_dir=os.path.join(FLAGS.model_dir, etype),
                 session_config=session_config,
                 save_checkpoints_steps=FLAGS.save_checkpoints_steps,
-                tpu_config=tf.contrib.tpu.TPUConfig(
+                tpu_config=tf.compat.v1.estimator.tpu.TPUConfig(
                     iterations_per_loop=FLAGS.iterations_per_loop,
                     num_shards=FLAGS.num_tpu_cores,
                     per_host_input_for_training=is_per_host))
@@ -425,7 +428,7 @@ class BioBERT:
                 use_tpu=FLAGS.use_tpu,
                 use_one_hot_embeddings=FLAGS.use_tpu)
 
-            estimator = tf.contrib.tpu.TPUEstimator(
+            estimator = tf.compat.v1.estimator.tpu.TPUEstimator(
                 use_tpu=FLAGS.use_tpu,
                 model_fn=model_fn,
                 config=run_config,
@@ -664,7 +667,7 @@ class BioBERT:
                                                  output_file, req_id,
                                                  mode='test'):
         features_list = list()
-        writer = tf.python_io.TFRecordWriter(output_file)
+        writer = tf.io.TFRecordWriter(output_file)
         for (ex_index, example) in enumerate(examples):
             feature = self.convert_single_example(example, max_seq_length,
                                                   req_id, mode)
@@ -885,4 +888,4 @@ def main(_):
 
 
 if __name__ == "__main__":
-    tf.app.run()
+    tf.compat.v1.app.run()

--- a/biobert_ner/tokenization.py
+++ b/biobert_ner/tokenization.py
@@ -25,6 +25,7 @@ import six
 import tensorflow as tf
 
 
+
 def validate_case_matches_checkpoint(do_lower_case, init_checkpoint):
     """Checks whether the casing config is consistent with the checkpoint name."""
 
@@ -123,7 +124,7 @@ def load_vocab(vocab_file):
     """Loads a vocabulary file into a dictionary."""
     vocab = collections.OrderedDict()
     index = 0
-    with tf.gfile.GFile(vocab_file, "r") as reader:
+    with tf.io.gfile.GFile(vocab_file, "r") as reader:
         while True:
             token = convert_to_unicode(reader.readline())
             if not token:

--- a/pmid_inference.py
+++ b/pmid_inference.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Standalone script to run BioBERT NER on PubMed abstracts by PMID."""
+import argparse
+import json
+
+from convert import pubtator_biocxml2dict_list
+from biobert_ner.run_ner import BioBERT, FLAGS
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run BioBERT NER on PMIDs")
+    parser.add_argument("--pmids", nargs="+", required=True,
+                        help="Space separated list of PMIDs to annotate")
+    parser.add_argument("--model_dir", required=True,
+                        help="Directory containing entity-specific checkpoints")
+    parser.add_argument("--bert_config_file", required=True,
+                        help="Path to bert_config.json")
+    parser.add_argument("--vocab_file", required=True,
+                        help="Path to vocab.txt")
+    parser.add_argument("--init_checkpoint", required=True,
+                        help="Checkpoint prefix, e.g., model.ckpt-1000000")
+    args = parser.parse_args()
+
+    # Initialize absl.FLAGS without parsing command line flags from absl
+    FLAGS(["pmid_inference"])
+    FLAGS.model_dir = args.model_dir
+    FLAGS.bert_config_file = args.bert_config_file
+    FLAGS.vocab_file = args.vocab_file
+    FLAGS.init_checkpoint = args.init_checkpoint
+
+    biobert = BioBERT(FLAGS)
+    pmid_list = [int(p) for p in args.pmids]
+    docs = pubtator_biocxml2dict_list(pmid_list)
+    results = biobert.recognize(docs)
+    biobert.close()
+
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy
-pandas
-requests
-tensorflow-gpu
-xmltodict
+tensorflow>=2.12
+numpy>=1.23
+pandas>=1.3
+requests>=2.28
+xmltodict>=0.13


### PR DESCRIPTION
## Summary
- Switch BioBERT model building to `tf.compat.v1` APIs for variable scopes and dense layers
- Remove deprecated TensorFlow 1 shape access in NER runtime

## Testing
- `python -m py_compile biobert_ner/*.py && echo 'PYCOMPILE_OK'`


------
https://chatgpt.com/codex/tasks/task_b_68b89b6d51ac8320b9fd8534885355a2